### PR TITLE
Fix attribute name mismatch for model path in `test_model.py`

### DIFF
--- a/src/test_model.py
+++ b/src/test_model.py
@@ -69,16 +69,16 @@ def main():
     # Only setup model if random model is not selected
     if not args.random_model:
         # Load model
-        if "RecurrentPPO" in args.modelpath:
-            model = RecurrentPPO.load(args.modelpath)
-        elif "PPO" in args.modelpath:
-            model = PPO.load(args.modelpath)
-        elif "DDPG" in args.modelpath:
-            model = DDPG.load(args.modelpath)
-        elif "SAC" in args.modelpath:
-            model = SAC.load(args.modelpath)
-        elif "DQN" in args.modelpath:
-            model = DQN.load(args.modelpath)
+        if "RecurrentPPO" in args.model_path:
+            model = RecurrentPPO.load(args.model_path)
+        elif "PPO" in args.model_path:
+            model = PPO.load(args.model_path)
+        elif "DDPG" in args.model_path:
+            model = DDPG.load(args.model_path)
+        elif "SAC" in args.model_path:
+            model = SAC.load(args.model_path)
+        elif "DQN" in args.model_path:
+            model = DQN.load(args.model_path)
         else:
             raise ValueError("Model not supported")
 


### PR DESCRIPTION
This PR fixes an attribute naming issue in `test_model.py`. The model path argument is defined as `--model-path` in the argument parser, which sets the attribute as `model_path`. 

However, the code was incorrectly using `args.modelpath`, resulting in an AttributeError. 
```
(driving) docker@9c6ffe358b63:~/src/src$ python test_model.py -m "./Training/Models/DDPG/2025-03-11_01-51-03/final_model.zip"  
pygame 2.4.0 (SDL 2.26.4, Python 3.8.20)
Hello from the pygame community. https://www.pygame.org/contribute.html
Env running on server carla_server
connecting to Carla server...
Carla server port 2000 connected!
Traceback (most recent call last):
  File "test_model.py", line 156, in <module>
    main()
  File "test_model.py", line 72, in main
    if "RecurrentPPO" in args.modelpath:
AttributeError: 'Namespace' object has no attribute 'modelpath'
```

This change updates all references to correctly use `args.model_path`, ensuring that the model path is properly recognized.

Please review and merge this fix. Thank you!
